### PR TITLE
Add test for large models, free model memory, and require options field

### DIFF
--- a/src/SolverAPI.jl
+++ b/src/SolverAPI.jl
@@ -95,7 +95,7 @@ function response(
     end
     res["solver_version"] = string(solver_name, '_', solver_ver)
 
-    res["termination_status"] = MOI.get(model, MOI.TerminationStatus())
+    res["termination_status"] = string(MOI.get(model, MOI.TerminationStatus()))
 
     options = get(() -> Dict{String,Any}(), json, :options)
     format = get(options, :print_format, nothing)
@@ -117,7 +117,7 @@ function response(
     for idx in 1:result_count
         r = results[idx]
 
-        r["primal_status"] = MOI.get(model, MOI.PrimalStatus(idx))
+        r["primal_status"] = string(MOI.get(model, MOI.PrimalStatus(idx)))
 
         # TODO: It is redundant to return the names for every result, since they are fixed -
         # try relying on fixed vector ordering and don't return names.

--- a/src/SolverAPI.jl
+++ b/src/SolverAPI.jl
@@ -97,13 +97,12 @@ function response(
 
     res["termination_status"] = string(MOI.get(model, MOI.TerminationStatus()))
 
-    options = get(() -> Dict{String,Any}(), json, :options)
-    format = get(options, :print_format, nothing)
+    format = get(json.options, :print_format, nothing)
     if !isnothing(format)
         res["model_string"] = print_model(model, format)
     end
 
-    if Bool(get(options, :print_only, false))
+    if Bool(get(json.options, :print_only, false))
         return res
     end
 
@@ -178,12 +177,23 @@ function solve(fn, json::Request, solver::MOI.AbstractOptimizer)
     errors = validate(json)
     isempty(errors) || return response(; errors)
 
+    # TODO (dba) `SolverAPI.jl` should be decoupled from any solver specific code.
+    solver_info = Dict{Symbol,Any}()
+    if lowercase(get(json.options, :solver, "highs")) == "minizinc"
+        T = Int
+        solver_info[:use_indicator] = false
+    else
+        T = Float64
+        solver_info[:use_indicator] = true
+    end
+
+    model = MOI.instantiate(() -> solver; with_cache_type = T, with_bridge_type = T)
+
     try
-        T, solver_info, model = initialize(json, solver)
-        load!(json, T, solver_info, model)
+        set_options!(model, json.options)
+        load!(model, json, T, solver_info)
         fn(model)
-        options = get(() -> Dict{String,Any}(), json, :options)
-        if !Bool(get(options, :print_only, false))
+        if !Bool(get(json.options, :print_only, false))
             MOI.optimize!(model)
         end
         return response(json, model, solver)
@@ -208,6 +218,8 @@ function solve(fn, json::Request, solver::MOI.AbstractOptimizer)
         else
             rethrow()
         end
+    finally
+        MOI.empty!(model)
     end
 end
 solve(request::Request, solver::MOI.AbstractOptimizer) =
@@ -232,30 +244,30 @@ function print_model(model::MOI.ModelLike, format::String)
     format_lower = lowercase(format)
     if format_lower == "moi" || format_lower == "latex"
         mime = MIME(format_lower == "latex" ? "text/latex" : "text/plain")
-        options = MOI.Utilities._PrintOptions(
+        print_options = MOI.Utilities._PrintOptions(
             mime;
             simplify_coefficients = true,
             print_types = false,
         )
         return sprint() do io
-            return MOI.Utilities._print_model(io, options, model)
+            return MOI.Utilities._print_model(io, print_options, model)
         end
     elseif format_lower == "latex"
         # NOTE: there are options for latex_formulation, e.g. don't print MOI function/set types
         # https://jump.dev/MathOptInterface.jl/dev/submodules/Utilities/reference/#MathOptInterface.Utilities.latex_formulation
         return sprint(print, MOI.Utilities.latex_formulation(model))
     elseif format_lower == "mof"
-        options = (; format = MOI.FileFormats.FORMAT_MOF, print_compact = true)
+        print_options = (; format = MOI.FileFormats.FORMAT_MOF, print_compact = true)
     elseif format_lower == "lp"
-        options = (; format = MOI.FileFormats.FORMAT_LP)
+        print_options = (; format = MOI.FileFormats.FORMAT_LP)
     elseif format_lower == "mps"
-        options = (; format = MOI.FileFormats.FORMAT_MPS)
+        print_options = (; format = MOI.FileFormats.FORMAT_MPS)
     elseif format_lower == "nl"
-        options = (; format = MOI.FileFormats.FORMAT_NL)
+        print_options = (; format = MOI.FileFormats.FORMAT_NL)
     else
         throw(Error(Unsupported, "File type \"$format\" not supported."))
     end
-    dest = MOI.FileFormats.Model(; options...)
+    dest = MOI.FileFormats.Model(; print_options...)
     MOI.copy_to(dest, model)
     return sprint(write, dest)
 end
@@ -265,16 +277,15 @@ function print_model(request::Request; T = Float64)
         throw(CompositeException(errors))
     end
 
-    options = get(() -> Dict{String,Any}(), request, :options)
     # Default to MOI format.
-    format = get(options, :print_format, "MOI")
+    format = get(request.options, :print_format, "MOI")
 
     # TODO cleanup/refactor solver_info logic.
     use_indicator = T == Float64
     solver_info = Dict{Symbol,Any}(:use_indicator => use_indicator)
     model = MOI.Utilities.Model{T}()
 
-    load!(request, T, solver_info, model)
+    load!(model, request, T, solver_info)
     return print_model(model, format)
 end
 print_model(request::Dict) = print_model(JSON3.read(JSON3.write(request)))
@@ -289,7 +300,7 @@ function validate(json::Request)#::Vector{Error}
     valid_shape = true
 
     # Syntax.
-    for k in [:version, :sense, :variables, :constraints, :objectives]
+    for k in [:version, :sense, :variables, :constraints, :objectives, :options]
         if !haskey(json, k)
             valid_shape = false
             _err("Missing required field `$(k)`.")
@@ -307,7 +318,7 @@ function validate(json::Request)#::Vector{Error}
         _err("Invalid version `$(repr(json.version))`. Only `\"0.1\"` is supported.")
     end
 
-    if haskey(json, :options) && !isa(json.options, JSON3.Object)
+    if !isa(json.options, JSON3.Object)
         _err("Invalid `options` field. Must be an object.")
     end
 
@@ -326,20 +337,18 @@ function validate(json::Request)#::Vector{Error}
         _err("Invalid `sense` field. Must be one of `feas`, `min`, or `max`.")
     end
 
-    if haskey(json, :options)
-        for (T, k) in [(String, :print_format), (Number, :time_limit_sec)]
-            if haskey(json.options, k) && !isa(json.options[k], T)
-                _err("Invalid `options.$(k)` field. Must be of type `$(T)`.")
-            end
+    for (T, k) in [(String, :print_format), (Number, :time_limit_sec)]
+        if haskey(json.options, k) && !isa(json.options[k], T)
+            _err("Invalid `options.$(k)` field. Must be of type `$(T)`.")
         end
+    end
 
-        for k in [:silent, :print_only]
-            if haskey(json.options, k)
-                val = json.options[k]
-                # We allow `0` and `1` for convenience.
-                if !isa(val, Bool) && val isa Number && val != 0 && val != 1
-                    _err("Invalid `options.$(k)` field. Must be a boolean.")
-                end
+    for k in [:silent, :print_only]
+        if haskey(json.options, k)
+            val = json.options[k]
+            # We allow `0` and `1` for convenience.
+            if !isa(val, Bool) && val isa Number && val != 0 && val != 1
+                _err("Invalid `options.$(k)` field. Must be a boolean.")
             end
         end
     end
@@ -357,29 +366,16 @@ function validate(json::Request)#::Vector{Error}
     return out
 end
 
-function initialize(json::Request, solver::MOI.AbstractOptimizer)#::Tuple{Type, Dict{Symbol, Any}, MOI.ModelLike}
-    solver_info = Dict{Symbol,Any}()
-
-    # TODO (dba) `SolverAPI.jl` should be decoupled from any solver specific code.
-    options = get(() -> Dict{String,Any}(), json, :options)
-    if lowercase(get(options, :solver, "highs")) == "minizinc"
-        T = Int
-        solver_info[:use_indicator] = false
-    else
-        T = Float64
-        solver_info[:use_indicator] = true
-    end
-
-    model = MOI.instantiate(() -> solver; with_cache_type = T, with_bridge_type = T)
-
+# Set solver options.
+function set_options!(model::MOI.ModelLike, options::JSON3.Object)#::Nothing
     if MOI.supports(model, MOI.TimeLimitSec())
         # Set time limit, defaulting to 5min.
         MOI.set(model, MOI.TimeLimitSec(), Float64(get(options, :time_limit_sec, 300.0)))
     end
 
-    # Set other solver options.
     for (key, val) in options
         if key in [:solver, :print_format, :print_only, :time_limit_sec]
+            # Skip - these are handled elsewhere.
             continue
         elseif key == :silent
             MOI.set(model, MOI.Silent(), Bool(val))
@@ -392,10 +388,10 @@ function initialize(json::Request, solver::MOI.AbstractOptimizer)#::Tuple{Type, 
         end
     end
 
-    return (T, solver_info, model)
+    return nothing
 end
 
-function load!(json::Request, T::Type, solver_info::Dict{Symbol,Any}, model::MOI.ModelLike)#::Nothing
+function load!(model::MOI.ModelLike, json::Request, T::Type, solver_info::Dict{Symbol,Any})#::Nothing
     # handle variables
     vars_map = Dict{String,MOI.VariableIndex}()
     vars = MOI.add_variables(model, length(json.variables))

--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -112,7 +112,7 @@ end
     using SolverAPI: solve
 
     # setup linear objective model with n variables
-    n = 20000
+    n = 1000
     vars = ["x$i" for i in 1:n]
     model = Dict(
         :version => "0.1",

--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -112,7 +112,7 @@ end
     using SolverAPI: solve
 
     # setup linear objective model with n variables
-    n = 5000
+    n = 20000
     vars = ["x$i" for i in 1:n]
     model = Dict(
         :version => "0.1",

--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -112,7 +112,7 @@ end
     using SolverAPI: solve
 
     # setup linear objective model with n variables
-    n = 2000
+    n = 5000
     vars = ["x$i" for i in 1:n]
     model = Dict(
         :version => "0.1",

--- a/test/inputs/missing_options.json
+++ b/test/inputs/missing_options.json
@@ -1,0 +1,1 @@
+{"version":"0.1","sense":"feas","variables":["x"],"constraints":[["==","x",1],["Int","x"]],"objectives":[]}


### PR DESCRIPTION
~~blocked by https://github.com/jump-dev/MathOptInterface.jl/pull/2288, so the first CI run should fail here.~~

this is the same type of test failure triggered by https://github.com/RelationalAI/SolverAPI.jl/pull/6, caused by a stack overflow from MOI.operate. but I made the test easier to work with because the model is set-up directly in the test rather than read from a JSON file, so you can change the size and expressions easily.

Thanks @bachdavi and @hdavid16 

I also made the options field required - it should always be present anyway - and that simplified the code a little and improved type stability. 

I also added a `MOI.empty!` to free the MOI model, whether there was an error or not.