### PR TITLE
Remove solver specific code

### DIFF
--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -27,8 +27,9 @@ function run_solve(input::String)
         "highs"
     end
     solver = get_solver(solver_name)
-    T = solver isa MiniZinc.Optimizer ? Int : Float64
-    output = solve(json, solver; bridge_type = T)
+    (numerical_type, use_indicator) =
+        solver isa MiniZinc.Optimizer ? (Int, false) : (Float64, true)
+    output = solve(json, solver; numerical_type, use_indicator)
     return String(serialize(output))
 end
 

--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -27,7 +27,8 @@ function run_solve(input::String)
         "highs"
     end
     solver = get_solver(solver_name)
-    output = solve(json, solver)
+    T = solver isa MiniZinc.Optimizer ? Int : Float64
+    output = solve(json, solver; bridge_type = T)
     return String(serialize(output))
 end
 


### PR DESCRIPTION
This PR removes solver-specific code by making the `bridge_type` an argument to `solve`. I was looking around to see if that information is generically present in `AbstractOptimizer`, but that seems to be the case only for MiniZinc and a selected few. 

This means that the caller of `SolverAPI.solve` is responsible for setting the type.
