### PR TITLE
Make options field optional

### DIFF
--- a/src/SolverAPI.jl
+++ b/src/SolverAPI.jl
@@ -362,6 +362,10 @@ function validate(json::Request)#::Vector{Error}
         _err("Invalid version `$(repr(json.version))`. Only `\"0.1\"` is supported.")
     end
 
+    if haskey(json, :options) && !isa(json.options, JSON3.Object)
+        _err("Invalid `options` field. Must be an object.")
+    end
+
     for k in [:variables, :constraints, :objectives]
         if !isa(json[k], JSON3.Array)
             _err("Invalid `$(k)` field. Must be an array.")

--- a/src/SolverAPI.jl
+++ b/src/SolverAPI.jl
@@ -332,7 +332,7 @@ function validate(json::Request)#::Vector{Error}
     valid_shape = true
 
     # Syntax.
-    for k in [:version, :sense, :variables, :constraints, :objectives, :options]
+    for k in [:version, :sense, :variables, :constraints, :objectives]
         if !haskey(json, k)
             valid_shape = false
             _err("Missing required field `$(k)`.")
@@ -350,10 +350,6 @@ function validate(json::Request)#::Vector{Error}
         _err("Invalid version `$(repr(json.version))`. Only `\"0.1\"` is supported.")
     end
 
-    if !isa(json.options, JSON3.Object)
-        _err("Invalid `options` field. Must be an object.")
-    end
-
     for k in [:variables, :constraints, :objectives]
         if !isa(json[k], JSON3.Array)
             _err("Invalid `$(k)` field. Must be an array.")
@@ -369,18 +365,20 @@ function validate(json::Request)#::Vector{Error}
         _err("Invalid `sense` field. Must be one of `feas`, `min`, or `max`.")
     end
 
-    for (T, k) in [(String, :print_format), (Number, :time_limit_sec)]
-        if haskey(json.options, k) && !isa(json.options[k], T)
-            _err("Invalid `options.$(k)` field. Must be of type `$(T)`.")
+    if haskey(json, :options)
+        for (T, k) in [(String, :print_format), (Number, :time_limit_sec)]
+            if haskey(json.options, k) && !isa(json.options[k], T)
+                _err("Invalid `options.$(k)` field. Must be of type `$(T)`.")
+            end
         end
-    end
 
-    for k in [:silent, :print_only]
-        if haskey(json.options, k)
-            val = json.options[k]
-            # We allow `0` and `1` for convenience.
-            if !isa(val, Bool) && val isa Number && val != 0 && val != 1
-                _err("Invalid `options.$(k)` field. Must be a boolean.")
+        for k in [:silent, :print_only]
+            if haskey(json.options, k)
+                val = json.options[k]
+                # We allow `0` and `1` for convenience.
+                if !isa(val, Bool) && val isa Number && val != 0 && val != 1
+                    _err("Invalid `options.$(k)` field. Must be a boolean.")
+                end
             end
         end
     end

--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -83,6 +83,7 @@ end
     # solve and check output is expected for each input json file
     @testset "$j" for j in json_names
         output = JSON3.read(run_solve(read_json("inputs", j)))
+        @info output
         @test output.solver_version isa String
         @test output.solve_time_sec isa Float64
         expect = JSON3.read(read_json("outputs", j))

--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -77,6 +77,7 @@ end
         "in_con_const_mip",
         "in_con_expr_csp",
         "empty_arr_con",
+        "no_options", # The `options` field is now optional. `HiGHS` will be used as the default solver.
     ]
 
     # solve and check output is expected for each input json file

--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -107,8 +107,6 @@ end
         ("missing_sense", "InvalidFormat"),
         # missing field version
         ("missing_version", "InvalidFormat"),
-        # missing field options
-        ("missing_options", "InvalidFormat"),
         # field variables is not a string
         ("vars_is_not_str", "InvalidFormat"),
         # field variables is not an array

--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -83,11 +83,9 @@ end
     # solve and check output is expected for each input json file
     @testset "$j" for j in json_names
         output = JSON3.read(run_solve(read_json("inputs", j)))
-        @info "output" output.results[1]
         @test output.solver_version isa String
         @test output.solve_time_sec isa Float64
         expect = JSON3.read(read_json("outputs", j))
-        @info "expect" expect.results[1]
         for (key, expect_value) in pairs(expect)
             @test output[key] == expect_value
         end

--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -83,10 +83,11 @@ end
     # solve and check output is expected for each input json file
     @testset "$j" for j in json_names
         output = JSON3.read(run_solve(read_json("inputs", j)))
-        @info output
+        @info "output" output
         @test output.solver_version isa String
         @test output.solve_time_sec isa Float64
         expect = JSON3.read(read_json("outputs", j))
+        @info "expect" expect
         for (key, expect_value) in pairs(expect)
             @test output[key] == expect_value
         end

--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -83,11 +83,11 @@ end
     # solve and check output is expected for each input json file
     @testset "$j" for j in json_names
         output = JSON3.read(run_solve(read_json("inputs", j)))
-        @info "output" output
+        @info "output" output.results[1]
         @test output.solver_version isa String
         @test output.solve_time_sec isa Float64
         expect = JSON3.read(read_json("outputs", j))
-        @info "expect" expect
+        @info "expect" expect.results[1]
         for (key, expect_value) in pairs(expect)
             @test output[key] == expect_value
         end

--- a/test/inputs/missing_options.json
+++ b/test/inputs/missing_options.json
@@ -1,1 +1,0 @@
-{"version":"0.1","sense":"feas","variables":["x"],"constraints":[["==","x",1],["Int","x"]],"objectives":[]}

--- a/test/inputs/no_options.json
+++ b/test/inputs/no_options.json
@@ -1,0 +1,1 @@
+{"version":"0.1","sense":"min","variables":["x"],"constraints":[["==","x",1],["Int","x"]],"objectives":["x"]}

--- a/test/outputs/no_options.json
+++ b/test/outputs/no_options.json
@@ -1,1 +1,1 @@
-{"termination_status":"OPTIMAL","results":[{"names":["\"x\""],"values":[1.0],"primal_status":"FEASIBLE_POINT","objective_value":1.0}],"version":"0.1"}
+{"termination_status":"OPTIMAL","results":[{"values":[1.0],"primal_status":"FEASIBLE_POINT","objective_value":1.0}],"version":"0.1"}

--- a/test/outputs/no_options.json
+++ b/test/outputs/no_options.json
@@ -1,0 +1,1 @@
+{"termination_status":"OPTIMAL","results":[{"names":["\"x\""],"values":[1.0],"primal_status":"FEASIBLE_POINT","objective_value":1.0}],"version":"0.1"}


### PR DESCRIPTION
We want to remove `solver` from the options field and pass it via HTTP query parameters instead.