### PR TITLE
Solver options via params argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Make `options` field optional [#22](https://github.com/RelationalAI/SolverAPI.jl/pull/22)
   - Remove `names` field in results [#20](https://github.com/RelationalAI/SolverAPI.jl/pull/20)
   - Update format to use JSON vector for relational appl constraint
-  args [#21](https://github.com/RelationalAI/SolverAPI.jl/pull/21)
+    args [#21](https://github.com/RelationalAI/SolverAPI.jl/pull/21)
 
 ## [0.2.2]
 

--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -92,6 +92,35 @@ end
     end
 end
 
+@testitem "solve - params" setup = [SolverSetup] begin
+    import JSON3
+    import HiGHS
+
+    using SolverAPI
+
+    tiny_min = JSON3.read(
+        JSON3.write(
+            Dict(
+                "version" => "0.1",
+                "sense" => "min",
+                "variables" => ["x"],
+                "constraints" => [["==", "x", 1], ["Int", "x"]],
+                "objectives" => ["x"],
+            ),
+        ),
+    )
+
+    # We can pass options to the solver via `params` as well. The
+    # `solver` key will be ignored.
+    result = solve(
+        tiny_min,
+        HiGHS.Optimizer(),
+        Dict{Symbol,Any}(:time_limit_sec => 0, :presolve => "off", :solver => "highs"),
+    )
+
+    @test result["termination_status"] == "TIME_LIMIT"
+end
+
 @testitem "errors" setup = [SolverSetup] begin
     using SolverAPI
     import JSON3


### PR DESCRIPTION
This PR allows passing a `Dict{Symbol,Any}` to `solve` that is used as solver options. In this way we can use HTTP query parameters to pass options instead of using the `options` field in the request.