### PR TITLE
Require `format` argument for `print_model`

### DIFF
--- a/src/SolverAPI.jl
+++ b/src/SolverAPI.jl
@@ -484,8 +484,6 @@ function set_options!(model::MOI.ModelLike, options::Dict{Symbol,Any})#::Nothing
 
     return nothing
 end
-set_options!(model::MOI.ModelLike, options::JSON3.Object) =
-    set_options!(model, copy(options))
 
 function load!(model::MOI.ModelLike, json::Request, solver_info::Dict{Symbol,Any})#::Nothing
     T = solver_info[:numerical_type]

--- a/src/SolverAPI.jl
+++ b/src/SolverAPI.jl
@@ -181,7 +181,7 @@ function _solve(
     fn,
     json::Request,
     solver::MOI.AbstractOptimizer,
-    params::Dict{Symbol,Any};
+    params::Union{JSON3.Object, Dict{Symbol,Any}};
     kw...,
 )
     errors = validate(json)
@@ -274,7 +274,7 @@ solve(request, solver, params = Dict{Symbol,Any}(); kw...) =
     solve(model -> nothing, request, solver, params; kw...)
 
 """
-    print_model(request::Request; <kwargs>)::String
+    print_model(request::Request, format::String; <kwargs>)::String
     print_model(model::MOI.ModelLike, format::String)::String
 
 Print the `model`. `format` options (case-insensitive) are:
@@ -323,7 +323,8 @@ function print_model(model::MOI.ModelLike, format::String)
     return sprint(write, dest)
 end
 function print_model(
-    request::Request;
+    request::Request,
+    format::String;
     use_indicator::Bool = true,
     numerical_type::Type{<:Real} = Float64,
 )
@@ -332,9 +333,6 @@ function print_model(
         throw(CompositeException(errors))
     end
 
-    # Default to MOI format.
-    format = get(request.options, :print_format, "MOI")
-
     solver_info =
         Dict{Symbol,Any}(:use_indicator => use_indicator, :numerical_type => numerical_type)
     model = MOI.Utilities.Model{numerical_type}()
@@ -342,7 +340,7 @@ function print_model(
     load!(model, request, solver_info)
     return print_model(model, format)
 end
-print_model(request::Dict; kw...) = print_model(JSON3.read(JSON3.write(request)); kw...)
+print_model(request::Dict, format::String; kw...) = print_model(JSON3.read(JSON3.write(request)), format; kw...)
 
 # Internal
 # ========================================================================================

--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -46,7 +46,7 @@ end # end of setup module.
         :sense => "min",
         :variables => ["x"],
         :constraints => [["==", "x", 1], ["Int", "x"]],
-        :objectives => ["x"]
+        :objectives => ["x"],
     )
 
     # check MOI model printing for each format
@@ -90,7 +90,36 @@ end
     end
 end
 
-@testitem "solve - params" setup = [SolverSetup] begin
+@testitem "solve - only params" setup = [SolverSetup] begin
+    import JSON3
+    import HiGHS
+
+    using SolverAPI
+
+    # The `options` field will be merged with the `params` argument.
+    tiny_min = JSON3.read(
+        JSON3.write(
+            Dict(
+                "version" => "0.1",
+                "sense" => "min",
+                "variables" => ["x"],
+                "constraints" => [["==", "x", 1], ["Int", "x"]],
+                "objectives" => ["x"],
+                "options" => Dict("presolve" => "off"),
+            ),
+        ),
+    )
+
+    result = solve(
+        tiny_min,
+        HiGHS.Optimizer(),
+        Dict{Symbol,Any}(:time_limit_sec => 0, :solver => "highs"),
+    )
+
+    @test result["termination_status"] == "TIME_LIMIT"
+end
+
+@testitem "solve - params and options" setup = [SolverSetup] begin
     import JSON3
     import HiGHS
 
@@ -115,6 +144,33 @@ end
         HiGHS.Optimizer(),
         Dict{Symbol,Any}(:time_limit_sec => 0, :presolve => "off", :solver => "highs"),
     )
+
+    @test result["termination_status"] == "TIME_LIMIT"
+end
+
+@testitem "solve - params as JSON" setup = [SolverSetup] begin
+    import JSON3
+    import HiGHS
+
+    using SolverAPI
+
+    tiny_min = JSON3.read(
+        JSON3.write(
+            Dict(
+                "version" => "0.1",
+                "sense" => "min",
+                "variables" => ["x"],
+                "constraints" => [["==", "x", 1], ["Int", "x"]],
+                "objectives" => ["x"],
+            ),
+        ),
+    )
+
+    params = Dict{Symbol,Any}(:time_limit_sec => 0, :presolve => "off", :solver => "highs")
+
+    # Passing params as `JSON3.Object` is also supported to avoid a
+    # copy.
+    result = solve(tiny_min, HiGHS.Optimizer(), JSON3.read(JSON3.write(params)))
 
     @test result["termination_status"] == "TIME_LIMIT"
 end

--- a/test/all_tests.jl
+++ b/test/all_tests.jl
@@ -46,14 +46,12 @@ end # end of setup module.
         :sense => "min",
         :variables => ["x"],
         :constraints => [["==", "x", 1], ["Int", "x"]],
-        :objectives => ["x"],
-        :options => Dict(:print_format => "none"),
+        :objectives => ["x"]
     )
 
     # check MOI model printing for each format
     @testset "$f" for f in ["moi", "latex", "mof", "lp", "mps", "nl"]
-        json[:options][:print_format] = f
-        @test print_model(json) isa String
+        @test print_model(json, f) isa String
     end
 end
 


### PR DESCRIPTION
This PR changes the signature of `print_model` that takes the JSON input and requires passing the format string. Previously, we'd use the `:print_format` that was in the `:options` field of the input. 

Additionally, we allow passing the `params` argument to `solve` as JSON. For this I also added some tests.